### PR TITLE
fixed #170 Useless profile icon multiple times.

### DIFF
--- a/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/DashboardActivity.kt
+++ b/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/DashboardActivity.kt
@@ -138,8 +138,20 @@ class DashboardActivity : MifosBaseActivity(), View.OnClickListener, NavigationV
         ivCircularUserProfilePicture.setOnClickListener(this)
     }
 
-    override fun onClick(v: View) {
+     override fun onClick(view: View?) {
         // Click Header to view full profile of User
+
+       when(view?.id) {
+           R.id.iv_circular_user_image->{
+               replaceFragment(CustomerDetailsFragment.newInstance("customer_identifier"), true,
+                       R.id.container)
+
+           }
+           R.id.iv_user_image->{
+               replaceFragment(CustomerDetailsFragment.newInstance("customer_identifier"), true,
+                       R.id.container)
+           }
+       }
     }
 
     private fun setUpBackStackListener() {


### PR DESCRIPTION
## Issue Fix
Fixes #170

## Short Video 

https://user-images.githubusercontent.com/72181295/105852870-02094200-600b-11eb-8348-618294bfaf4e.mp4


<!--Please Add Screenshots or Screen Recordings which show the changes that you made.-->

## Description
I created onClick methods for ivTextDrawableUserProfilePicture.setOnClickListener(this) , 
 ivCircularUserProfilePicture.setOnClickListener(this) at DashboardActivity.kt
<!--Please Add Summary of the changes that you have made.-->

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
